### PR TITLE
Implement adapter to return PCI identifiers

### DIFF
--- a/Adapter/Adapter.vcxproj
+++ b/Adapter/Adapter.vcxproj
@@ -148,6 +148,7 @@
     <ClInclude Include="NVAPIAdapter.h" />
     <ClInclude Include="NVAPIStatusInterpreter.h" />
     <ClInclude Include="pch.h" />
+    <ClInclude Include="PciIdentifier.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="NVAPITunnel.cpp" />

--- a/Adapter/Adapter.vcxproj.filters
+++ b/Adapter/Adapter.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="NVAPIError.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="PciIdentifier.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp">

--- a/Adapter/NVAPIAdapter.cpp
+++ b/Adapter/NVAPIAdapter.cpp
@@ -67,5 +67,18 @@ namespace Adapter
 		}
 		return gpuType == NV_GPU_TYPE::NV_SYSTEM_TYPE_DGPU ? "Discrete" : "Integrated";
 	}
+
+	PciIdentifier NVAPIAdapter::GetPciIdentifiers()
+	{
+		// TODO: Assert API initialized.
+		PciIdentifier identifier;
+		NvAPI_Status status = NVAPITunnel::GetPciIdentifiers(m_physicalHandler, identifier);
+		if (status == NvAPI_Status::NVAPI_OK) 
+		{
+			return identifier;
+		}
+		const std::string message = "Failed to get PCI identifiers. " + NVAPIStatusInterpreter::GetStatusMessage(status);
+		throw NVAPIError(message);
+	}
 }
 

--- a/Adapter/NVAPIAdapter.cpp
+++ b/Adapter/NVAPIAdapter.cpp
@@ -70,7 +70,7 @@ namespace Adapter
 
 	PciIdentifier NVAPIAdapter::GetPciIdentifiers()
 	{
-		// TODO: Assert API initialized.
+		AssertApiInitialized();
 		PciIdentifier identifier;
 		NvAPI_Status status = NVAPITunnel::GetPciIdentifiers(m_physicalHandler, identifier);
 		if (status == NvAPI_Status::NVAPI_OK) 

--- a/Adapter/NVAPIAdapter.h
+++ b/Adapter/NVAPIAdapter.h
@@ -2,6 +2,7 @@
 
 #include "Export.h"
 #include <nvapi.h>
+#include "PciIdentifier.h"
 
 namespace AdapterUnitTest 
 {
@@ -35,6 +36,8 @@ namespace Adapter
 
 		/// <returns>The type of GPU installed (integrated, discrete, or unknown).</returns>
 		ADAPTER_API std::string GetGpuType();
+
+		ADAPTER_API PciIdentifier GetPciIdentifiers();
 
 	private:
 		/// <summary>

--- a/Adapter/NVAPITunnel.cpp
+++ b/Adapter/NVAPITunnel.cpp
@@ -27,4 +27,9 @@ namespace Adapter
 	{
 		return NvAPI_GPU_GetGPUType(physicalHandler, gpuType);
 	}
+
+	NvAPI_Status NVAPITunnel::GetPciIdentifiers(const NvPhysicalGpuHandle physicalHandler, PciIdentifier& pciIdentifier)
+	{
+		return NvAPI_GPU_GetPCIIdentifiers(physicalHandler, &pciIdentifier.m_internalId, &pciIdentifier.m_subsystemId, &pciIdentifier.m_revisionId, &pciIdentifier.m_externalId);
+	}
 }

--- a/Adapter/NVAPITunnel.h
+++ b/Adapter/NVAPITunnel.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Export.h"
+#include "PciIdentifier.h"
 #include <nvapi.h>
 
 namespace Adapter
@@ -35,5 +36,11 @@ namespace Adapter
 		/// <param name="gpuType">Stores the GPU type of the graphics card.</param>
 		/// <returns>The status of the NVAPI library upon attempting to get the GPU type.</returns>
 		ADAPTER_API NvAPI_Status GetGpuType(const NvPhysicalGpuHandle physicalHandler, NV_GPU_TYPE* gpuType);
+
+		/// <summary>Determins the PCI identifiers associated with the graphics card.</summary>
+		/// <param name="physicalHandler">NVAPI handler interfacing with the specific graphics card.</param>
+		/// <param name="pciIdentifier">Stores the PCI identifiers.</param>
+		/// <returns>The status of the NVAPI library upon attemptiong to get the PCI indentifiers.</returns>
+		ADAPTER_API NvAPI_Status GetPciIdentifiers(const NvPhysicalGpuHandle physicalHandler, PciIdentifier& pciIdentifier);
 	}
 }

--- a/Adapter/PciIdentifier.h
+++ b/Adapter/PciIdentifier.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace Adapter
+{
+	/// <summary>Provides PCI identifiers associated with GPU.</summary>
+	struct PciIdentifier
+	{
+		unsigned long m_internalId{ 0ul };
+		unsigned long m_subsystemId{ 0ul };
+		unsigned long m_revisionId{ 0ul };
+		unsigned long m_externalId{ 0ul };
+
+		PciIdentifier() = default;
+	};
+}

--- a/Adapter/UnitTest/NVAPIAdapterTester.cpp
+++ b/Adapter/UnitTest/NVAPIAdapterTester.cpp
@@ -310,6 +310,28 @@ namespace AdapterUnitTest
 			FailTestForNotThrowing();
 		}
 
+		TEST_METHOD(GetPciIdentifiers_WhenApiNotInitialized_Throws)
+		{
+			// Arrange
+			const std::string expectedMessage = "Fake API not initialized error.";
+			MockRepository mocks;
+			mocks.OnCallFunc(NVAPIStatusInterpreter::GetStatusMessage).Return(expectedMessage);
+			auto adapter = std::make_unique<NVAPIAdapter>(m_fakePhysicalHandler);
+
+			try
+			{
+				// Act
+				adapter->GetPciIdentifiers();
+			}
+			catch (const NVAPIError& error)
+			{
+				// Assert
+				Assert::AreEqual(expectedMessage, error.m_message);
+				return;
+			}
+			FailTestForNotThrowing();
+		}
+
 	private:
 		NvPhysicalGpuHandle m_fakePhysicalHandler{ 0 };
 


### PR DESCRIPTION
## Description
- Implements the `GetPciIdentifiers` function.
- Consolidate common mock behavior in unit tests to single `Rig` functions.